### PR TITLE
fix(1007): Add getLinks method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Screwdriver
 
-Have a look at our guidelines, as well as pointers on where to start making changes, in our official [documentation](http://docs.screwdriver.cd/about/contributing).
+Have a look at our guidelines, as well as pointers on where to start making changes, in our official [documentation](https://docs.screwdriver.cd/about/contributing/pull-requests).

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 Yahoo Inc.
+Copyright 2018 Yahoo Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ npm install screwdriver-screwdriver-coverage-sonar
 npm test
 ```
 
+## Related Links
+- See [coverage-base](https://github.com/screwdriver-cd/coverage-base)
+
 ## License
 
 Code licensed under the BSD 3-Clause license. See LICENSE file for terms.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Usage
 
 ```bash
-npm install screwdriver-screwdriver-coverage-sonar
+npm install screwdriver-coverage-sonar
 ```
 
 ## Testing
@@ -22,13 +22,13 @@ npm test
 
 Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 
-[npm-image]: https://img.shields.io/npm/v/screwdriver-screwdriver-coverage-sonar.svg
-[npm-url]: https://npmjs.org/package/screwdriver-screwdriver-coverage-sonar
-[downloads-image]: https://img.shields.io/npm/dt/screwdriver-screwdriver-coverage-sonar.svg
-[license-image]: https://img.shields.io/npm/l/screwdriver-screwdriver-coverage-sonar.svg
+[npm-image]: https://img.shields.io/npm/v/screwdriver-coverage-sonar.svg
+[npm-url]: https://npmjs.org/package/screwdriver-coverage-sonar
+[downloads-image]: https://img.shields.io/npm/dt/screwdriver-coverage-sonar.svg
+[license-image]: https://img.shields.io/npm/l/screwdriver-coverage-sonar.svg
 [issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver-coverage-sonar.svg
 [issues-url]: https://github.com/screwdriver-cd/screwdriver-coverage-sonar/issues
-[status-image]: https://cd.screwdriver.cd/pipelines/pipelineid/badge
-[status-url]: https://cd.screwdriver.cd/pipelines/pipelineid
+[status-image]: https://cd.screwdriver.cd/pipelines/706/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/706
 [daviddm-image]: https://david-dm.org/screwdriver-cd/screwdriver-coverage-sonar.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/screwdriver-cd/screwdriver-coverage-sonar

--- a/index.js
+++ b/index.js
@@ -155,6 +155,19 @@ class CoverageSonar extends CoverageBase {
     }
 
     /**
+     * Return links to the Sonar badge and project
+     * @method getLinks
+     * @param   {Object} jobId    Project ID
+     * @return  {Promise}         An object with coverage badge link and project link
+     */
+    _getLinks(jobId) {
+        return Promise.resolve({
+            badge: `${this.config.sonarHost}/api/badges/measure?key=job%3A${jobId}&metric=coverage`,
+            project: `${this.config.sonarHost}/dashboard?id=job%3A${jobId}`
+        });
+    }
+
+    /**
      * Get shell command to upload coverage to server
      * @method _getUploadCoverageCmd
      * @return {Promise}     Shell commands to upload coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-coverage-sonar",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "SonarQube implementation of the coverage-base class",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
     "joi": "^13.2.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
-    "screwdriver-coverage-base": "^1.0.1",
+    "screwdriver-coverage-base": "^1.0.3",
     "uuid": "^3.2.1"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,6 +64,19 @@ describe('index test', () => {
         });
     });
 
+    describe('getLinks', () => {
+        it('returns links', () => {
+            console.log('links');
+
+            return sonarPlugin.getLinks('1').then(result =>
+                assert.deepEqual(result, {
+                    badge: `${config.sonarHost}/api/badges/measure?key=job%3A1&metric=coverage`,
+                    project: `${config.sonarHost}/dashboard?id=job%3A1`
+                })
+            );
+        });
+    });
+
     describe('getAccessToken', () => {
         const buildCredentials = { jobId: 1 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,9 +66,7 @@ describe('index test', () => {
 
     describe('getLinks', () => {
         it('returns links', () => {
-            console.log('links');
-
-            return sonarPlugin.getLinks('1').then(result =>
+            sonarPlugin.getLinks('1').then(result =>
                 assert.deepEqual(result, {
                     badge: `${config.sonarHost}/api/badges/measure?key=job%3A1&metric=coverage`,
                     project: `${config.sonarHost}/dashboard?id=job%3A1`


### PR DESCRIPTION
## Context
Users would like to get a link to their badge and how to get to the project.

## Objective
This PR adds a method getLinks to return badge and project links.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1007
Blocked by https://github.com/screwdriver-cd/coverage-base/pull/6