### PR TITLE
fix(1007): Take in object for getInfo (2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,10 +157,12 @@ class CoverageSonar extends CoverageBase {
     /**
      * Return links to the Sonar badge and project
      * @method getLinks
-     * @param   {Object} jobId    Project ID
-     * @return  {Promise}         An object with coverage badge link and project link
+     * @param   {Object}  config
+     * @param   {String}  config.buildId    Screwdriver build ID
+     * @param   {String}  config.jobId      Screwdriver job ID
+     * @return  {Promise}                   An object with coverage badge link and project link
      */
-    _getLinks(jobId) {
+    _getLinks({ jobId }) {
         return Promise.resolve({
             badge: `${this.config.sonarHost}/api/badges/measure?key=job%3A${jobId}&metric=coverage`,
             project: `${this.config.sonarHost}/dashboard?id=job%3A${jobId}`

--- a/index.js
+++ b/index.js
@@ -155,17 +155,22 @@ class CoverageSonar extends CoverageBase {
     }
 
     /**
-     * Return links to the Sonar badge and project
-     * @method getLinks
+     * Return links to the Sonar project and coverage metadata
+     * @method getInfo
      * @param   {Object}  config
-     * @param   {String}  config.buildId    Screwdriver build ID
      * @param   {String}  config.jobId      Screwdriver job ID
+     * @param   {String}  config.startTime  Job start time
+     * @param   {String}  config.endTime    Job end time
      * @return  {Promise}                   An object with coverage badge link and project link
      */
-    _getLinks({ jobId }) {
+    _getInfo({ jobId, startTime, endTime }) {
+        // eslint-disable-next-line max-len
+        const coverageUrl = `${this.config.sonarHost}/api/measures/search_history?component=job:${encodeURIComponent(jobId)}&metrics=coverage&from=${encodeURIComponent(startTime)}&to=${encodeURIComponent(endTime)}`;
+        const projectUrl = `${this.config.sonarHost}/dashboard?id=job:${encodeURIComponent(jobId)}`;
+
         return Promise.resolve({
-            badge: `${this.config.sonarHost}/api/badges/measure?key=job%3A${jobId}&metric=coverage`,
-            project: `${this.config.sonarHost}/dashboard?id=job%3A${jobId}`
+            coverage: coverageUrl,
+            project: projectUrl
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "joi": "^13.2.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
-    "screwdriver-coverage-base": "^1.0.3",
+    "screwdriver-coverage-base": "^1.0.4",
     "uuid": "^3.2.1"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "joi": "^13.2.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
-    "screwdriver-coverage-base": "^1.0.4",
+    "screwdriver-coverage-base": "^1.0.5",
     "uuid": "^3.2.1"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,14 +65,17 @@ describe('index test', () => {
     });
 
     describe('getLinks', () => {
-        it('returns links', () => {
-            sonarPlugin.getLinks('1').then(result =>
+        it('returns links', () =>
+            sonarPlugin.getLinks({
+                buildId: '123',
+                jobId: '1'
+            }).then((result) => {
                 assert.deepEqual(result, {
                     badge: `${config.sonarHost}/api/badges/measure?key=job%3A1&metric=coverage`,
                     project: `${config.sonarHost}/dashboard?id=job%3A1`
-                })
-            );
-        });
+                });
+            })
+        );
     });
 
     describe('getAccessToken', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,15 +64,18 @@ describe('index test', () => {
         });
     });
 
-    describe('getLinks', () => {
+    describe('getInfo', () => {
         it('returns links', () =>
-            sonarPlugin.getLinks({
+            sonarPlugin.getInfo({
                 buildId: '123',
-                jobId: '1'
+                jobId: '1',
+                startTime: '2017-10-19T13:00:00+0200',
+                endTime: '2017-10-19T15:00:00+0200'
             }).then((result) => {
                 assert.deepEqual(result, {
-                    badge: `${config.sonarHost}/api/badges/measure?key=job%3A1&metric=coverage`,
-                    project: `${config.sonarHost}/dashboard?id=job%3A1`
+                    // eslint-disable-next-line max-len
+                    coverage: `${config.sonarHost}/api/measures/search_history?component=job:1&metrics=coverage&from=2017-10-19T13%3A00%3A00%2B0200&to=2017-10-19T15%3A00%3A00%2B0200`,
+                    project: `${config.sonarHost}/dashboard?id=job:1`
                 });
             })
         );


### PR DESCRIPTION
Some coverage plugins might need the `buildId`, the sonar coverage plugin requires the `jobId`. We'll have the UI pass in both since it should have access to both and the coverage plugin will decide what to do with it.

Example call to Sonar for coverage data: https://sonar.screwdriver.cd/api/measures/search_history?component=job%3A6071&metrics=coverage&ps=1&from=2017-10-19
Or: https://sonar.screwdriver.cd/api/measures/search_history?component=job%3A6071&metrics=coverage&ps=1&from=2017-10-19T13%3A00%3A00%2B0200

Blocked by https://github.com/screwdriver-cd/coverage-base/pull/7
Related to https://github.com/screwdriver-cd/screwdriver/issues/1007