### PR TITLE
fix(1084): Add sdApiAuthUrl and sonarHost to getInfo results [1]

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -4,5 +4,5 @@ export SD_CURL_CMD_WRAPPER="sd-step exec --pkg-version 7.54.1 core/curl"
 export SD_UNZIP_CMD_WRAPPER="sd-step exec --pkg-version 6.0 core/unzip"
 $SD_CURL_CMD_WRAPPER "curl -o ./sonarscanner.zip -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141-linux.zip"
 $SD_UNZIP_CMD_WRAPPER "unzip -q ./sonarscanner.zip"
-SONAR_TOKEN=`$SD_CURL_CMD_WRAPPER "curl -H \"Authorization: Bearer $SD_TOKEN\" $SD_COVERAGE_AUTH_URL"`
-sonar-scanner-3.1.0.1141-linux/bin/sonar-scanner -Dsonar.host.url=$SD_COVERAGE_HOST -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey="job:$SD_JOB_ID" -Dsonar.projectName="$SD_PIPELINE_NAME:$SD_JOB_NAME" -Dsonar.projectVersion=$SD_BUILD_SHA $SD_SONAR_OPTS
+SONAR_TOKEN=`$SD_CURL_CMD_WRAPPER "curl -H \"Authorization: Bearer $SD_TOKEN\" $SD_SONAR_AUTH_URL"`
+sonar-scanner-3.1.0.1141-linux/bin/sonar-scanner -Dsonar.host.url=$SD_SONAR_HOST -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey="job:$SD_JOB_ID" -Dsonar.projectName="$SD_PIPELINE_NAME:$SD_JOB_NAME" -Dsonar.projectVersion=$SD_BUILD_SHA $SD_SONAR_OPTS

--- a/commands.txt
+++ b/commands.txt
@@ -4,5 +4,5 @@ export SD_CURL_CMD_WRAPPER="sd-step exec --pkg-version 7.54.1 core/curl"
 export SD_UNZIP_CMD_WRAPPER="sd-step exec --pkg-version 6.0 core/unzip"
 $SD_CURL_CMD_WRAPPER "curl -o ./sonarscanner.zip -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141-linux.zip"
 $SD_UNZIP_CMD_WRAPPER "unzip -q ./sonarscanner.zip"
-SONAR_TOKEN=`$SD_CURL_CMD_WRAPPER "curl -H \"Authorization: Bearer $SD_TOKEN\" $SD_API_AUTH_URL"`
-sonar-scanner-3.1.0.1141-linux/bin/sonar-scanner -Dsonar.host.url=$SONAR_HOST -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey="job:$SD_JOB_ID" -Dsonar.projectName="$SD_PIPELINE_NAME:$SD_JOB_NAME" -Dsonar.projectVersion=$SD_BUILD_SHA $SD_SONAR_OPTS
+SONAR_TOKEN=`$SD_CURL_CMD_WRAPPER "curl -H \"Authorization: Bearer $SD_TOKEN\" $SD_COVERAGE_AUTH_URL"`
+sonar-scanner-3.1.0.1141-linux/bin/sonar-scanner -Dsonar.host.url=$SD_COVERAGE_HOST -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey="job:$SD_JOB_ID" -Dsonar.projectName="$SD_PIPELINE_NAME:$SD_JOB_NAME" -Dsonar.projectVersion=$SD_BUILD_SHA $SD_SONAR_OPTS

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.1.0",
-    "sinon": "^5.0.4"
+    "sinon": "^5.1.1"
   },
   "dependencies": {
     "hoek": "^5.0.3",
-    "joi": "^13.2.0",
-    "request": "^2.85.0",
+    "joi": "^13.4.0",
+    "request": "^2.87.0",
     "request-promise-native": "^1.0.5",
     "screwdriver-coverage-base": "^1.0.5",
     "uuid": "^3.2.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('index test', () => {
     const config = {
         sdApiUrl: 'https://api.screwdriver.cd',
-        coverageHost: 'https://sonar.screwdriver.cd',
+        sonarHost: 'https://sonar.screwdriver.cd',
         adminToken: 'faketoken'
     };
     const coverageObject = {
@@ -98,9 +98,11 @@ describe('index test', () => {
                     `https://sonar.screwdriver.cd/api/measures/search_history?component=job%3A1&metrics=coverage&from=2017-10-19T13%3A00%3A00${timezoneOffset}&to=2017-10-19T15%3A00%3A00${timezoneOffset}&ps=1` }));
                 assert.deepEqual(result, {
                     coverage: '98.8',
-                    projectUrl: `${config.coverageHost}/dashboard?id=job%3A1`,
-                    sdCoverageAuthUrl: 'https://api.screwdriver.cd/v4/coverage/token',
-                    coverageHost: 'https://sonar.screwdriver.cd'
+                    projectUrl: `${config.sonarHost}/dashboard?id=job%3A1`,
+                    envVars: {
+                        SD_SONAR_AUTH_URL: 'https://api.screwdriver.cd/v4/coverage/token',
+                        SD_SONAR_HOST: 'https://sonar.screwdriver.cd'
+                    }
                 });
             });
         });
@@ -112,8 +114,10 @@ describe('index test', () => {
                 jobId: '1'
             }).then((result) => {
                 assert.deepEqual(result, {
-                    sdCoverageAuthUrl: 'https://api.screwdriver.cd/v4/coverage/token',
-                    coverageHost: 'https://sonar.screwdriver.cd'
+                    envVars: {
+                        SD_SONAR_AUTH_URL: 'https://api.screwdriver.cd/v4/coverage/token',
+                        SD_SONAR_HOST: 'https://sonar.screwdriver.cd'
+                    }
                 });
             });
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('index test', () => {
     const config = {
         sdApiUrl: 'https://api.screwdriver.cd',
-        sonarHost: 'https://sonar.screwdriver.cd',
+        coverageHost: 'https://sonar.screwdriver.cd',
         adminToken: 'faketoken'
     };
     const coverageObject = {
@@ -98,7 +98,22 @@ describe('index test', () => {
                     `https://sonar.screwdriver.cd/api/measures/search_history?component=job%3A1&metrics=coverage&from=2017-10-19T13%3A00%3A00${timezoneOffset}&to=2017-10-19T15%3A00%3A00${timezoneOffset}&ps=1` }));
                 assert.deepEqual(result, {
                     coverage: '98.8',
-                    projectUrl: `${config.sonarHost}/dashboard?id=job%3A1`
+                    projectUrl: `${config.coverageHost}/dashboard?id=job%3A1`,
+                    sdCoverageAuthUrl: 'https://api.screwdriver.cd/v4/coverage/token',
+                    coverageHost: 'https://sonar.screwdriver.cd'
+                });
+            });
+        });
+
+        it('returns links when startTime and endTime are not passed in', () => {
+            requestMock.onCall(0).resolves(coverageObject);
+
+            return sonarPlugin.getInfo({
+                jobId: '1'
+            }).then((result) => {
+                assert.deepEqual(result, {
+                    sdCoverageAuthUrl: 'https://api.screwdriver.cd/v4/coverage/token',
+                    coverageHost: 'https://sonar.screwdriver.cd'
                 });
             });
         });


### PR DESCRIPTION
`getInfo` method should return other data so we can set `$SD_API_AUTH_URL` and `$SONAR_HOST` in launcher

Also renaming env vars to more generic names.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1084