### PR TITLE
fix(1452): convert measures from array to object

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,13 +136,20 @@ function getMetrics({ jobId, startTime, endTime }) {
         }
     })
         .then((result) => {
+            const measures = {};
+
+            // measures in result is an array, covert it to an object with metric name as key
+            (hoek.reach(result, 'measures') || []).forEach((measure) => {
+                measures[measure.metric] = measure;
+            });
+
             const metrics = {
-                coverage: hoek.reach(result, 'measures.3.history.0.value') || 'N/A',
+                coverage: hoek.reach(measures, 'coverage.history.0.value') || 'N/A',
                 tests: 'N/A'
             };
-            const total = hoek.reach(result, 'measures.0.history.0.value');
-            const testErrors = hoek.reach(result, 'measures.1.history.0.value');
-            const testFailures = hoek.reach(result, 'measures.2.history.0.value');
+            const total = hoek.reach(measures, 'tests.history.0.value');
+            const testErrors = hoek.reach(measures, 'test_errors.history.0.value');
+            const testFailures = hoek.reach(measures, 'test_failures.history.0.value');
 
             if (total) {
                 const totalInt = parseInt(total, 10);


### PR DESCRIPTION
The measures return by sonar api is an array, however the order is not always guarantee to be the order we put in the query.

This PR will convert measures to an object and the key will be the metric name.

Before convert:
```
   [ { metric: 'tests', history: [Array] },
     { metric: 'test_errors', history: [Array] },
     { metric: 'test_failures', history: [Array] },
     { metric: 'coverage', history: [Array] } ] 
```

After convert:
```
{ tests: { metric: 'tests', history: [ [Object] ] },
  test_errors: { metric: 'test_errors', history: [ [Object] ] },
  test_failures: { metric: 'test_failures', history: [ [Object] ] },
  coverage: { metric: 'coverage', history: [ [Object] ] } }
```


Related to: https://github.com/screwdriver-cd/screwdriver/issues/1452