### PR TITLE
Use hoek default to set unset values to 0 for tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,9 +147,9 @@ function getMetrics({ jobId, startTime, endTime }) {
                 coverage: hoek.reach(measures, 'coverage.history.0.value') || 'N/A',
                 tests: 'N/A'
             };
-            const total = hoek.reach(measures, 'tests.history.0.value');
-            const testErrors = hoek.reach(measures, 'test_errors.history.0.value');
-            const testFailures = hoek.reach(measures, 'test_failures.history.0.value');
+            const total = hoek.reach(measures, 'tests.history.0.value', { default: 0 });
+            const testErrors = hoek.reach(measures, 'test_errors.history.0.value', { default: 0 });
+            const testFailures = hoek.reach(measures, 'test_failures.history.0.value', { default: 0 });
 
             if (total) {
                 const totalInt = parseInt(total, 10);

--- a/index.js
+++ b/index.js
@@ -148,11 +148,11 @@ function getMetrics({ jobId, startTime, endTime }) {
                 tests: 'N/A'
             };
             const zero = { default: 0 };
-            const total = hoek.reach(measures, 'tests.history.0.value', zero);
+            const total = hoek.reach(measures, 'tests.history.0.value', { default: "N/A" });
             const testErrors = hoek.reach(measures, 'test_errors.history.0.value', zero);
             const testFailures = hoek.reach(measures, 'test_failures.history.0.value', zero);
 
-            if (total) {
+            if (!Number.isNaN(Number(total)) ) {
                 const totalInt = parseInt(total, 10);
                 const pass = totalInt - parseInt(testErrors, 10) - parseInt(testFailures, 10);
 

--- a/index.js
+++ b/index.js
@@ -147,9 +147,10 @@ function getMetrics({ jobId, startTime, endTime }) {
                 coverage: hoek.reach(measures, 'coverage.history.0.value') || 'N/A',
                 tests: 'N/A'
             };
-            const total = hoek.reach(measures, 'tests.history.0.value', { default: 0 });
-            const testErrors = hoek.reach(measures, 'test_errors.history.0.value', { default: 0 });
-            const testFailures = hoek.reach(measures, 'test_failures.history.0.value', { default: 0 });
+            const zero = { default: 0 };
+            const total = hoek.reach(measures, 'tests.history.0.value', zero);
+            const testErrors = hoek.reach(measures, 'test_errors.history.0.value', zero);
+            const testFailures = hoek.reach(measures, 'test_failures.history.0.value', zero);
 
             if (total) {
                 const totalInt = parseInt(total, 10);

--- a/index.js
+++ b/index.js
@@ -148,11 +148,11 @@ function getMetrics({ jobId, startTime, endTime }) {
                 tests: 'N/A'
             };
             const zero = { default: 0 };
-            const total = hoek.reach(measures, 'tests.history.0.value', { default: "N/A" });
+            const total = hoek.reach(measures, 'tests.history.0.value', { default: 'N/A' });
             const testErrors = hoek.reach(measures, 'test_errors.history.0.value', zero);
             const testFailures = hoek.reach(measures, 'test_failures.history.0.value', zero);
 
-            if (!Number.isNaN(Number(total)) ) {
+            if (!Number.isNaN(Number(total))) {
                 const totalInt = parseInt(total, 10);
                 const pass = totalInt - parseInt(testErrors, 10) - parseInt(testFailures, 10);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,6 +195,28 @@ describe('index test', () => {
             }));
         });
 
+        it('return N/A for tests if it tests metric history value is not a number', () => {
+            const obj = JSON.parse(JSON.stringify(coverageObject));
+
+            obj.measures[0].history[0].value = 'unknown';
+            requestMock.onCall(0).resolves(obj);
+
+            return sonarPlugin.getInfo({
+                buildId: '123',
+                jobId: '1',
+                startTime: '2017-10-19T13:00:00.123Z',
+                endTime: '2017-10-19T15:00:00.234Z'
+            }).then(result => assert.deepEqual(result, {
+                coverage: '98.8',
+                tests: 'N/A',
+                projectUrl: `${config.sonarHost}/dashboard?id=job%3A1`,
+                envVars: {
+                    SD_SONAR_AUTH_URL: 'https://api.screwdriver.cd/v4/coverage/token',
+                    SD_SONAR_HOST: 'https://sonar.screwdriver.cd'
+                }
+            }));
+        });
+
         it('computes correct result if tests_errors metric is missing', () => {
             const obj = JSON.parse(JSON.stringify(coverageObject));
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -174,8 +174,9 @@ describe('index test', () => {
         });
 
         it('return N/A for tests if it tests metric does not exist', () => {
-            delete coverageObject.measures[0];
-            requestMock.onCall(0).resolves(coverageObject);
+            let obj = JSON.parse(JSON.stringify(coverageObject));
+            delete obj.measures[0];
+            requestMock.onCall(0).resolves(obj);
 
             return sonarPlugin.getInfo({
                 buildId: '123',
@@ -185,6 +186,27 @@ describe('index test', () => {
             }).then(result => assert.deepEqual(result, {
                 coverage: '98.8',
                 tests: 'N/A',
+                projectUrl: `${config.sonarHost}/dashboard?id=job%3A1`,
+                envVars: {
+                    SD_SONAR_AUTH_URL: 'https://api.screwdriver.cd/v4/coverage/token',
+                    SD_SONAR_HOST: 'https://sonar.screwdriver.cd'
+                }
+            }));
+        });
+
+        it('computes correct result if tests_errors metric is missing', () => {
+            let obj = JSON.parse(JSON.stringify(coverageObject));
+            delete obj.measures[1].history[0].value;
+            requestMock.onCall(0).resolves(obj);
+
+            return sonarPlugin.getInfo({
+                buildId: '123',
+                jobId: '1',
+                startTime: '2017-10-19T13:00:00.123Z',
+                endTime: '2017-10-19T15:00:00.234Z'
+            }).then(result => assert.deepEqual(result, {
+                coverage: '98.8',
+                tests: '9/10',
                 projectUrl: `${config.sonarHost}/dashboard?id=job%3A1`,
                 envVars: {
                     SD_SONAR_AUTH_URL: 'https://api.screwdriver.cd/v4/coverage/token',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -174,7 +174,8 @@ describe('index test', () => {
         });
 
         it('return N/A for tests if it tests metric does not exist', () => {
-            let obj = JSON.parse(JSON.stringify(coverageObject));
+            const obj = JSON.parse(JSON.stringify(coverageObject));
+
             delete obj.measures[0];
             requestMock.onCall(0).resolves(obj);
 
@@ -195,7 +196,8 @@ describe('index test', () => {
         });
 
         it('computes correct result if tests_errors metric is missing', () => {
-            let obj = JSON.parse(JSON.stringify(coverageObject));
+            const obj = JSON.parse(JSON.stringify(coverageObject));
+
             delete obj.measures[1].history[0].value;
             requestMock.onCall(0).resolves(obj);
 


### PR DESCRIPTION
Avoids getting NaN when something like testErrors is "missing"


## Context

Currently my Go project passes all 244 tests, i.e. testErrors is 0.  It appears that the Sonar Go test plugin does *not* set the `test_errors` metric in this case, 
[output.txt](https://github.com/screwdriver-cd/coverage-sonar/files/3719994/output.txt)

## Objective

Defaults unset test values to 0

## References

Internal

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
