### PR TITLE
fix: make timezone match regex non-greedy

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function generateToken(username) {
 function getMetrics({ jobId, startTime, endTime }) {
     const componentId = encodeURIComponent(`job:${jobId}`);
     // get timezone offset (e.g. -0700) from 'Fri May 11 2018 15:25:37 GMT-0700 (PDT)'
-    const timezoneOffset = new Date().toString().match(/GMT(.*) /)[1];
+    const timezoneOffset = new Date().toString().match(/GMT(.*?) /)[1];
     // Convert the time format from 2018-05-10T19:05:53.123Z to 2018-05-10T19:05:53-0700 as required by sonar
     const parsedStartTime = startTime.replace(/\.(.*)/, timezoneOffset);
     const parsedEndTime = endTime.replace(/\.(.*)/, timezoneOffset);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -33,8 +33,9 @@
     "chai": "^3.5.0",
     "eslint": "^4.3.0",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^8.0.0",
+    "mocha": "^7.0.1",
     "mockery": "^2.1.0",
+    "nyc": "^15.0.0",
     "sinon": "^5.1.1"
   },
   "dependencies": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,7 +113,7 @@ describe('index test', () => {
     describe('getInfo', () => {
         it('returns links', () => {
             requestMock.onCall(0).resolves(coverageObject);
-            const timezoneOffset = encodeURIComponent(new Date().toString().match(/GMT(.*) /)[1]);
+            const timezoneOffset = encodeURIComponent(new Date().toString().match(/GMT(.*?) /)[1]);
 
             return sonarPlugin.getInfo({
                 buildId: '123',


### PR DESCRIPTION

## Context

current regex
```
new Date().toString().match(/GMT(.*) /)
[
  'GMT-0800 (Pacific Standard ',
  '-0800 (Pacific Standard',
  index: 25,
  input: 'Thu Feb 20 2020 12:07:28 GMT-0800 (Pacific Standard Time)',
  groups: undefined
]
```

with change
```
 new Date().toString().match(/GMT(.*?) /)
[
  'GMT-0800 ',
  '-0800',
  index: 25,
  input: 'Thu Feb 20 2020 12:08:45 GMT-0800 (Pacific Standard Time)',
  groups: undefined
]
```
## Objective

update regex for timezone match to be non-greedy

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
