### PR TITLE
fix: Quiet 404 error

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,8 +162,8 @@ function getMetrics({ jobId, startTime, endTime }) {
             return metrics;
         })
         .catch((err) => {
-            // if there is no coverage measurement target, 404 is returned and this is not an error
-            if (err.statusCode !== 404) {
+            // if there is no coverage measurement target, 404 and 'Component key not found' are returned and this is not an error
+            if (err.statusCode !== 404 || !/Component key '.*' not found/.test(err.message)) {
                 // if cannot get coverage, do not throw err
                 // eslint-disable-next-line max-len
                 logger.error(`Failed to get coverage and tests percentage for job ${jobId}: ${err.message}`);

--- a/index.js
+++ b/index.js
@@ -162,9 +162,12 @@ function getMetrics({ jobId, startTime, endTime }) {
             return metrics;
         })
         .catch((err) => {
-            // if cannot get coverage, do not throw err
-            // eslint-disable-next-line max-len
-            logger.error(`Failed to get coverage and tests percentage for job ${jobId}: ${err.message}`);
+            // if there is no coverage measurement target, 404 is returned and this is not an error
+            if (err.statusCode !== 404) {
+                // if cannot get coverage, do not throw err
+                // eslint-disable-next-line max-len
+                logger.error(`Failed to get coverage and tests percentage for job ${jobId}: ${err.message}`);
+            }
 
             return {
                 tests: 'N/A',


### PR DESCRIPTION
## Context
If the coverage data does not exist on SonarQube, such as when user delete the data from it, SonarQube returns a 404 response. This does not need to be treated as an error for Screwdriver.
 
## Objective
I want to quiet a 404 error, as I may miss other important errors.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
