### PR TITLE
fix(2152): Only use prParentJobId for enterprise sonar and job scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ function getProjectData({ scope, enterpriseEnabled, jobId: buildJobId,
     }
 
     // Use prParentJobId as ID for PRs
-    if (prNum && coverageScope === 'job') {
+    if (prNum && coverageScope === 'job' && enterpriseEnabled) {
         const prRegex = /^PR-(\d+)(?::([\w-]+))?$/;
         const prNameMatch = jobName.match(prRegex);
 
@@ -307,9 +307,11 @@ class CoverageSonar extends CoverageBase {
         if (!username || !projectKey) {
             projectData = getProjectData({
                 enterpriseEnabled: sonarEnterprise,
-                jobId: prParentJobId || jobId,
+                jobId,
+                prParentJobId,
                 pipelineId,
-                scope
+                scope,
+                projectKey
             });
         }
 
@@ -317,7 +319,7 @@ class CoverageSonar extends CoverageBase {
 
         return createProject(projectData.projectKey)
             .then(() => createUser(projectData.username, password))
-            .then(() => grantUserPermission(projectData.username, projectKey))
+            .then(() => grantUserPermission(projectData.username, projectData.projectKey))
             .then(() => generateToken(projectData.username))
             .then(res => res.token);
     }


### PR DESCRIPTION
## Context

For enterprise users with job scope, should not create new project for PR job, just use prParentJobId.

## Objective

This PR adds a check to make sure only use prParentJobId for job scope and enterprise Sonar.
Also passes in extra data to getProjectData.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
