### PR TITLE
feat(1958): Upgrade hapi dependencies. BREAKING CHANGE: hapi v19

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const joi = require('joi');
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 const path = require('path');
 const request = require('request-promise-native');
 const uuidv4 = require('uuid/v4');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-coverage-sonar",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "SonarQube implementation of the coverage-base class",
   "main": "index.js",
   "scripts": {
@@ -39,8 +39,8 @@
     "sinon": "^5.1.1"
   },
   "dependencies": {
-    "hoek": "^5.0.3",
-    "joi": "^13.4.0",
+    "@hapi/hoek": "^9.0.4",
+    "joi": "^17.2.1",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5",
     "screwdriver-coverage-base": "^2.0.0",


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
