### PR TITLE
fix: use reportPaths instead of reportPath

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,7 +4,7 @@ shared:
 jobs:
     main:
         environment:
-            SD_SONAR_OPTS: "-Dsonar.sources=index.js -Dsonar.javascript.lcov.reportPath=artifacts/coverage/lcov.info"
+            SD_SONAR_OPTS: "-Dsonar.sources=index.js -Dsonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info"
         requires: [~pr, ~commit]
         steps:
             - install: npm install


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
reportPath has been removed since sonarqube 6.x LTS, we should use reportPaths instead

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
use reportPaths

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
