### PR TITLE
fix(1961): New request package returns full response

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,7 +375,7 @@ class CoverageSonar extends CoverageBase {
             .then(() => createUser(projectData.username, password))
             .then(() => grantUserPermission(projectData.username, projectData.projectKey))
             .then(() => generateToken(projectData.username))
-            .then(res => res.token);
+            .then(res => res.body.token);
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -648,7 +648,7 @@ describe('index test', () => {
 
         beforeEach(() => {
             requestMock.onCall(1).rejects();
-            requestMock.onCall(4).resolves({ token: 'accesstoken' });
+            requestMock.onCall(4).resolves({ body: { token: 'accesstoken' } });
         });
 
         it('gets an access token successfully', () => {
@@ -672,7 +672,7 @@ describe('index test', () => {
             const username = 'user-pipeline-123';
 
             enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
-            requestMock.onCall(5).resolves({ token: 'accesstoken' });
+            requestMock.onCall(5).resolves({ body: { token: 'accesstoken' } });
 
             return enterpriseSonarPlugin
                 .getAccessToken({ buildCredentials, projectKey, username, projectName })
@@ -705,7 +705,7 @@ describe('index test', () => {
                 statusCode: 400,
                 message: 'Project already exists.'
             });
-            requestMock.onCall(4).resolves({ token: 'accesstoken' });
+            requestMock.onCall(4).resolves({ body: { token: 'accesstoken' } });
 
             return sonarPlugin.getAccessToken({ buildCredentials }).then(result => {
                 assert.callCount(requestMock, 5);
@@ -718,7 +718,7 @@ describe('index test', () => {
                 statusCode: 400,
                 message: 'user already exists.'
             });
-            requestMock.onCall(4).resolves({ token: 'accesstoken' });
+            requestMock.onCall(4).resolves({ body: { token: 'accesstoken' } });
 
             return sonarPlugin.getAccessToken({ buildCredentials }).then(result => {
                 assert.callCount(requestMock, 5);
@@ -753,7 +753,7 @@ describe('index test', () => {
             const username = 'user-pipeline-123';
 
             enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
-            requestMock.onCall(5).resolves({ token: 'accesstoken' });
+            requestMock.onCall(5).resolves({ body: { token: 'accesstoken' } });
 
             // eslint-disable-next-line max-len
             return enterpriseSonarPlugin
@@ -773,7 +773,7 @@ describe('index test', () => {
             const username = 'user-pipeline-123';
 
             enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
-            requestMock.onCall(4).resolves({ token: 'accesstoken' });
+            requestMock.onCall(4).resolves({ body: { token: 'accesstoken' } });
 
             // eslint-disable-next-line max-len
             return enterpriseSonarPlugin


### PR DESCRIPTION
## Context

The auth is broken for SonarQube.

## Objective

This PR gets token from response body correctly.

## References

Related to https://github.com/screwdriver-cd/coverage-sonar/pull/60

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
