### PR TITLE
fix: Add monorepo param for set_github_binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function configureGitApp(projectKey, projectName) {
             return Promise.resolve();
         }
 
-        const parameters = `almSetting=${gitAppEncoded}&project=${componentId}&repository=${projectName}&summaryCommentEnabled=true`;
+        const parameters = `almSetting=${gitAppEncoded}&project=${componentId}&repository=${projectName}&summaryCommentEnabled=true&monorepo=false`;
 
         return request({
             method: 'POST',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chai": "^4.2.0",
     "eslint": "^7.31.0",
     "eslint-config-screwdriver": "^5.0.1",
-    "mocha": "^8.3.2",
+    "mocha": "^9.1.3",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.1.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -687,7 +687,7 @@ describe('index test', () => {
                     assert.calledWith(
                         requestMock.thirdCall,
                         sinon.match({
-                            url: `https://sonar.screwdriver.cd/api/alm_settings/set_github_binding?almSetting=${gitAppEncoded}&project=pipeline%3A123&repository=${projectName}&summaryCommentEnabled=true`
+                            url: `https://sonar.screwdriver.cd/api/alm_settings/set_github_binding?almSetting=${gitAppEncoded}&project=pipeline%3A123&repository=${projectName}&summaryCommentEnabled=true&monorepo=false`
                         })
                     );
                     assert.call(


### PR DESCRIPTION
## Context

PR decoration is failing with the requirement of a `monorepo` param.
```
{ "message": "Failed to configure Git App Screwdriver Sonar PR Checks for Sonar project pipeline:1234567: 400 Reason \"{\"errors\":[{\"msg\":\"The 'monorepo' parameter is missing\"}]}\"", "level": "error", "timestamp": "2021-09-29T07:10:12.493Z" }
```

<img width="963" alt="Screen Shot 2021-10-27 at 2 07 10 PM" src="https://user-images.githubusercontent.com/3230529/139147471-b1069659-7378-4da6-9f8c-6c0e4de792cd.png">

## Objective

This PR:
- adds monorepo param to set_github_binding call
- updates to mocha v9.0

_Note: [mocha 9.0 no longer supports node.js v10](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#900--2021-06-07)_

## References
N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
