### PR TITLE
fix: Use correct job name for PR with job scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,8 +281,7 @@ class CoverageSonar extends CoverageBase {
         pipelineId,
         pipelineName,
         projectKey,
-        prParentJobId,
-        prNum
+        prParentJobId
     }) {
         let jobId = buildJobId;
         let jobName = buildJobName;
@@ -315,12 +314,14 @@ class CoverageSonar extends CoverageBase {
         }
 
         // Use prParentJobId as ID for PRs
-        if (prNum && coverageScope === 'job' && enterpriseEnabled) {
+        if (coverageScope === 'job' && enterpriseEnabled) {
             const prRegex = /^PR-(\d+)(?::([\w-]+))?$/;
             const prNameMatch = jobName.match(prRegex);
 
-            jobId = prParentJobId;
-            jobName = prNameMatch && prNameMatch.length > 1 ? prNameMatch[2] : jobName;
+            if (prNameMatch && prNameMatch.length > 1) {
+                jobId = prParentJobId;
+                jobName = prNameMatch[2];
+            }
         }
 
         return {
@@ -412,8 +413,7 @@ class CoverageSonar extends CoverageBase {
             pipelineName,
             jobName,
             projectKey: coverageProjectKey,
-            prParentJobId,
-            prNum
+            prParentJobId
         });
 
         const infoObject = {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^4.2.0",
-    "eslint": "^7.31.0",
+    "chai": "^4.3.6",
+    "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.1",
-    "mocha": "^9.1.3",
+    "mocha": "^9.2.2",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.1.0",
@@ -40,11 +40,11 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.2.0",
-    "joi": "^17.4.1",
+    "@hapi/hoek": "^9.3.0",
+    "joi": "^17.6.0",
     "screwdriver-coverage-base": "^2.1.0",
     "screwdriver-logger": "^1.1.0",
-    "screwdriver-request": "^1.0.1",
+    "screwdriver-request": "^1.0.3",
     "uuid": "^3.4.0"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -402,7 +402,7 @@ describe('index test', () => {
                     endTime,
                     pipelineId: 123,
                     prNum: 56,
-                    jobName: 'main',
+                    jobName: 'PR-56:main',
                     pipelineName: 'd2lam/mytest',
                     scope: 'job',
                     prParentJobId: 456
@@ -423,6 +423,45 @@ describe('index test', () => {
                             SD_SONAR_HOST: 'https://sonar.screwdriver.cd',
                             SD_SONAR_ENTERPRISE: true,
                             SD_SONAR_PROJECT_KEY: 'job:456',
+                            SD_SONAR_PROJECT_NAME: projectName
+                        }
+                    });
+                    assert.callCount(requestMock, 1);
+                });
+        });
+
+        it('returns links for enterprise project with job scope annotation', () => {
+            requestMock.onCall(0).resolves(coverageObject);
+            enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
+            const projectName = 'd2lam/mytest:main';
+
+            return enterpriseSonarPlugin
+                .getInfo({
+                    jobId: '1',
+                    startTime,
+                    endTime,
+                    pipelineId: 123,
+                    jobName: 'main',
+                    pipelineName: 'd2lam/mytest',
+                    scope: 'job',
+                    prParentJobId: 456
+                })
+                .then(result => {
+                    assert.calledWith(
+                        requestMock,
+                        sinon.match({
+                            url: `https://sonar.screwdriver.cd/api/measures/search_history?component=job%3A1&metrics=tests,test_errors,test_failures,coverage&from=2017-10-19T13%3A00%3A00${timezoneOffset}&to=2017-10-19T15%3A00%3A00${timezoneOffset}&ps=1`
+                        })
+                    );
+                    assert.deepEqual(result, {
+                        coverage: '98.8',
+                        tests: '7/10',
+                        projectUrl: `${config.sonarHost}/dashboard?id=job%3A1`,
+                        envVars: {
+                            SD_SONAR_AUTH_URL: `${sdSonarAuthUrl}?projectKey=job:1&projectName=d2lam/mytest:main&username=user-job-1&scope=job`,
+                            SD_SONAR_HOST: 'https://sonar.screwdriver.cd',
+                            SD_SONAR_ENTERPRISE: true,
+                            SD_SONAR_PROJECT_KEY: 'job:1',
                             SD_SONAR_PROJECT_NAME: projectName
                         }
                     });


### PR DESCRIPTION
## Context

When users have a PR job with scope job set, the Sonar project name will show with full PR job name: `screwdriver-cd/ui:PR-327:pull-request-name`. (SonarQube Enterprise Edition - Version 9.5)

## Objective

This PR switches to using parent job name for Sonar project for PR job with job scope.

## References

NA

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
