### PR TITLE
Fix: coverage token authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ npm install screwdriver-coverage-sonar
 npm test
 ```
 
+## Breaking change: `getAccessToken` no longer trusts caller-supplied project identity
+
+For security reasons, `getAccessToken` now validates any caller-supplied `projectKey` against an allowlist
+derived from the build's own JWT (`getAuthorizedProjectKeys`), and only trusts it when it also matches the
+build's own configured coverage scope; an unauthorized key is rejected with a `403`, and an
+authorized-but-wrong-scope key is ignored (logged as a mismatch, not enforced). `projectName` and `username`
+are never trusted at all — both are always derived. `username` is checked against the derived value and
+triggers the mismatch warning on its own; `projectName` is accepted only for backward compatibility and is
+included in that warning's message text when one fires, but a stale or bogus `projectName` alone does not
+trigger it.
+
+A caller that still sends only the old resolved tuple (`projectKey`/`username`/`projectName`, no
+`pipelineName`) will still successfully mint a token, but the Git App binding (`configureGitApp`) may be
+skipped for newly created enterprise projects, since it now depends on a resolved `pipelineName` rather than
+a caller-supplied `projectName`. See the `getAccessToken` JSDoc in `index.js` for the full parameter contract.
+
 ## Related Links
 - See [coverage-base](https://github.com/screwdriver-cd/coverage-base)
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const joi = require('joi');
+const boom = require('@hapi/boom');
 const hoek = require('@hapi/hoek');
 const path = require('path');
 const request = require('screwdriver-request');
@@ -332,6 +333,26 @@ class CoverageSonar extends CoverageBase {
     }
 
     /**
+     * Determine which Sonar project keys a build is allowed to act on.
+     * Derived exclusively from the build JWT, never from caller-supplied input.
+     * @method getAuthorizedProjectKeys
+     * @param  {Object}  buildCredentials                   Information stored in a build JWT
+     * @param  {String}  [buildCredentials.jobId]           Screwdriver job ID
+     * @param  {String}  [buildCredentials.pipelineId]      Screwdriver pipeline ID
+     * @param  {String}  [buildCredentials.prParentJobId]   Screwdriver PR parent job ID
+     * @return {Array}                                      Sonar project keys the build may use
+     */
+    getAuthorizedProjectKeys({ jobId, pipelineId, prParentJobId }) {
+        const ids = [
+            ['pipeline', pipelineId],
+            ['job', jobId],
+            ['job', prParentJobId]
+        ];
+
+        return ids.filter(([, id]) => id !== undefined && id !== null).map(([prefix, id]) => `${prefix}:${id}`);
+    }
+
+    /**
      * Determine Sonar project key, project name, and username based on:
      * - SonarQube edition
      * - job annotation
@@ -426,27 +447,44 @@ class CoverageSonar extends CoverageBase {
      * @param {Object} config.buildCredentials  Information stored in a build JWT
      * @param {String} [config.jobName]         Screwdriver job name
      * @param {String} config.pipelineName      Screwdriver pipeline name
-     * @param {String} [config.projectKey]      Sonar project key
+     * @param {String} [config.projectKey]      Sonar project key; must belong to the calling build
      * @param {String} [config.projectName]     Sonar project name
-     * @param {String} [config.username]        Sonar username
+     * @param {String} [config.username]        Ignored; the Sonar username is derived from the project key
      * @return {Promise}                        An access token that build can use
      *                                          to talk to coverage server
      */
     _getAccessToken({ scope, username, projectKey, projectName, jobName, pipelineName, buildCredentials }) {
         const { jobId, pipelineId, prParentJobId, scmContext } = buildCredentials;
-        let projectData = { username, projectKey, projectName };
+        const authorizedProjectKeys = this.getAuthorizedProjectKeys({ jobId, pipelineId, prParentJobId });
 
-        if (!username || !projectKey || !projectName || projectName.includes('undefined')) {
-            projectData = this.getProjectData({
-                enterpriseEnabled: this.sonarEnterprise,
-                jobId,
-                jobName,
-                prParentJobId,
-                pipelineId,
-                pipelineName,
-                scope,
-                projectKey
-            });
+        // A build may only ever request a token for its own pipeline or job. See PSECBUGS-115276.
+        if (projectKey && !authorizedProjectKeys.includes(String(projectKey))) {
+            logger.error(
+                `Rejected coverage token request for project ${projectKey} from build in pipeline ${pipelineId} / ` +
+                    `job ${jobId}; authorized: ${authorizedProjectKeys.join(', ')}`
+            );
+
+            return Promise.reject(
+                boom.forbidden(`Not authorized to request a coverage token for project ${projectKey}`)
+            );
+        }
+
+        // The Sonar username is always derived from the (verified) project key, never taken from the caller,
+        // so a build cannot mint a token for an arbitrary Sonar user such as an admin.
+        const derived = this.getProjectData({
+            enterpriseEnabled: this.sonarEnterprise,
+            jobId,
+            jobName,
+            prParentJobId,
+            pipelineId,
+            pipelineName,
+            scope,
+            projectKey
+        });
+        let projectData = derived;
+
+        if (username && projectKey && projectName && !projectName.includes('undefined')) {
+            projectData = { username: derived.username, projectKey, projectName };
         }
 
         const password = uuidv4();

--- a/index.js
+++ b/index.js
@@ -353,6 +353,21 @@ class CoverageSonar extends CoverageBase {
     }
 
     /**
+     * Resolve the coverage scope: the caller-configured scope when there is one, otherwise the default
+     * for this SonarQube edition (pipeline for enterprise, job for everything else).
+     * @method _resolveCoverageScope
+     * @param  {Object}     config
+     * @param  {String}     [config.scope]              Coverage scope (pipeline or job)
+     * @param  {Boolean}    config.enterpriseEnabled    If enterprise is enabled
+     * @return {String}                                 Resolved coverage scope
+     */
+    _resolveCoverageScope({ scope, enterpriseEnabled }) {
+        const userScope = scope && scope !== 'undefined' ? scope : undefined;
+
+        return userScope || (enterpriseEnabled ? 'pipeline' : 'job');
+    }
+
+    /**
      * Determine Sonar project key, project name, and username based on:
      * - SonarQube edition
      * - job annotation
@@ -403,9 +418,7 @@ class CoverageSonar extends CoverageBase {
             return projectData;
         }
 
-        // Use user-configured scope; otherwise figure out default scope: pipeline scope for enterprise edition, job scope for everything else
-        const userScope = scope && scope !== 'undefined' ? scope : undefined;
-        const coverageScope = userScope || (enterpriseEnabled ? 'pipeline' : 'job');
+        const coverageScope = this._resolveCoverageScope({ scope, enterpriseEnabled });
 
         if (coverageScope === 'pipeline') {
             const componentId = encodeURIComponent(`pipeline:${pipelineId}`);
@@ -420,14 +433,16 @@ class CoverageSonar extends CoverageBase {
             };
         }
 
-        // Use prParentJobId as ID for PRs
-        if (coverageScope === 'job' && enterpriseEnabled) {
+        // Use prParentJobId as ID for PRs. jobName is what identifies a PR job, so without it a PR build
+        // falls back to its own job's project rather than its parent's; callers that cannot resolve jobName
+        // must not crash here.
+        if (coverageScope === 'job' && enterpriseEnabled && jobName) {
             const prRegex = /^PR-(\d+)(?::([\w-]+))?$/;
             const prNameMatch = jobName.match(prRegex);
 
             if (prNameMatch && prNameMatch.length > 1) {
                 jobId = prParentJobId;
-                jobName = prNameMatch[2];
+                [, , jobName] = prNameMatch;
             }
         }
 
@@ -447,9 +462,16 @@ class CoverageSonar extends CoverageBase {
      * @param {Object} config.buildCredentials  Information stored in a build JWT
      * @param {String} [config.jobName]         Screwdriver job name
      * @param {String} config.pipelineName      Screwdriver pipeline name
-     * @param {String} [config.projectKey]      Sonar project key; must belong to the calling build
-     * @param {String} [config.projectName]     Sonar project name
-     * @param {String} [config.username]        Ignored; the Sonar username is derived from the project key
+     * @param {String} [config.projectKey]      Sonar project key; only honored if it names a project the
+     *                                          calling build is authorized for, and matches the build's own
+     *                                          coverage scope; otherwise ignored (logged as a mismatch)
+     * @param {String} [config.projectName]     Ignored; retained for backward compatibility. Always derived,
+     *                                          never taken from the caller. Included in the mismatch warning
+     *                                          message when projectKey or username mismatches, but does not
+     *                                          itself trigger that warning (pipelineName, its derivation
+     *                                          source, is unavailable to legacy callers on every request).
+     * @param {String} [config.username]        Ignored; retained for backward compatibility and mismatch
+     *                                          logging only. Always derived from the project key.
      * @return {Promise}                        An access token that build can use
      *                                          to talk to coverage server
      */
@@ -457,7 +479,7 @@ class CoverageSonar extends CoverageBase {
         const { jobId, pipelineId, prParentJobId, scmContext } = buildCredentials;
         const authorizedProjectKeys = this.getAuthorizedProjectKeys({ jobId, pipelineId, prParentJobId });
 
-        // A build may only ever request a token for its own pipeline or job. See PSECBUGS-115276.
+        // A build may only ever request a token for its own pipeline or job.
         if (projectKey && !authorizedProjectKeys.includes(String(projectKey))) {
             logger.error(
                 `Rejected coverage token request for project ${projectKey} from build in pipeline ${pipelineId} / ` +
@@ -469,9 +491,17 @@ class CoverageSonar extends CoverageBase {
             );
         }
 
-        // The Sonar username is always derived from the (verified) project key, never taken from the caller,
-        // so a build cannot mint a token for an arbitrary Sonar user such as an admin.
-        const derived = this.getProjectData({
+        // An authorized key is only trusted when it also matches the build's own configured coverage
+        // scope - otherwise a build could use an authorized key for the *other* scope (its own pipeline and
+        // its own job are both always "authorized") to cross from job to pipeline scope or back.
+        const coverageScope = this._resolveCoverageScope({ scope, enterpriseEnabled: this.sonarEnterprise });
+        const trustedProjectKey = projectKey && projectKey.split(':')[0] === coverageScope ? projectKey : undefined;
+
+        // projectName and username are never trusted here, even when projectKey is: every Sonar call below
+        // runs with the instance-wide admin token, so a caller-supplied projectName would let a build point
+        // another project's Git App binding at an arbitrary repository, and a caller-supplied username would
+        // let a build mint a token for an arbitrary Sonar account. Both are always derived instead.
+        const projectData = this.getProjectData({
             enterpriseEnabled: this.sonarEnterprise,
             jobId,
             jobName,
@@ -479,12 +509,17 @@ class CoverageSonar extends CoverageBase {
             pipelineId,
             pipelineName,
             scope,
-            projectKey
+            projectKey: trustedProjectKey
         });
-        let projectData = derived;
 
-        if (username && projectKey && projectName && !projectName.includes('undefined')) {
-            projectData = { username: derived.username, projectKey, projectName };
+        if ((projectKey && projectKey !== projectData.projectKey) || (username && username !== projectData.username)) {
+            logger.warn(
+                `Coverage token request for build in pipeline ${pipelineId} / job ${jobId} supplied ` +
+                    `projectKey=${JSON.stringify(projectKey)}, username=${JSON.stringify(username)}, ` +
+                    `projectName=${JSON.stringify(projectName)}, but derived ` +
+                    `projectKey=${JSON.stringify(projectData.projectKey)}, ` +
+                    `username=${JSON.stringify(projectData.username)} instead; using the derived values`
+            );
         }
 
         const password = uuidv4();

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sinon": "^15.0.0"
   },
   "dependencies": {
+    "@hapi/boom": "^10.0.1",
     "@hapi/hoek": "^11.0.7",
     "joi": "^17.13.3",
     "screwdriver-coverage-base": "^4.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -913,6 +913,91 @@ describe('index test', () => {
                 );
         });
 
+        it('rejects a project key belonging to another pipeline', () => {
+            return sonarPlugin
+                .getAccessToken({ buildCredentials, projectKey: 'pipeline:999' })
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch(err => {
+                    assert.strictEqual(err.output.statusCode, 403);
+                    assert.strictEqual(
+                        err.message,
+                        'Not authorized to request a coverage token for project pipeline:999'
+                    );
+                    // nothing may reach Sonar with the admin token
+                    assert.notCalled(requestMock);
+                    assert.calledOnce(loggerMock.error);
+                });
+        });
+
+        it('rejects a project key belonging to another job', () => {
+            return sonarPlugin
+                .getAccessToken({ buildCredentials, projectKey: 'job:999' })
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch(err => {
+                    assert.strictEqual(err.output.statusCode, 403);
+                    assert.notCalled(requestMock);
+                });
+        });
+
+        it('rejects a project key that only prefixes an authorized key', () => {
+            return sonarPlugin
+                .getAccessToken({ buildCredentials, projectKey: 'pipeline:123:evil' })
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch(err => {
+                    assert.strictEqual(err.output.statusCode, 403);
+                    assert.notCalled(requestMock);
+                });
+        });
+
+        it('ignores a caller-supplied username and derives it from the project key', () => {
+            return sonarPlugin
+                .getAccessToken({
+                    buildCredentials,
+                    projectKey: 'pipeline:123',
+                    projectName: 'd2lam/mytest',
+                    username: 'admin'
+                })
+                .then(result => {
+                    assert.strictEqual(result, 'accesstoken');
+                    assert.include(
+                        requestMock.getCall(3).args[0].url,
+                        '/api/users/create?login=user-pipeline-123&name=user-pipeline-123&password='
+                    );
+                    assert.neverCalledWith(requestMock, sinon.match({ url: sinon.match('login=admin') }));
+                });
+        });
+
+        it('allows the PR parent job key for an enterprise PR build', () => {
+            const prBuildCredentials = { jobId: 1, pipelineId: 123, prParentJobId: 456, scmContext: 'github.com' };
+
+            enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
+            // enterprise adds a set_github_binding call, so generateToken lands one slot later
+            requestMock.onCall(6).resolves({ body: { token: 'accesstoken' } });
+
+            return enterpriseSonarPlugin
+                .getAccessToken({
+                    buildCredentials: prBuildCredentials,
+                    projectKey: 'job:456',
+                    projectName: 'd2lam/mytest',
+                    scope: 'job'
+                })
+                .then(result => {
+                    assert.strictEqual(result, 'accesstoken');
+                    assert.calledWith(
+                        requestMock.firstCall,
+                        sinon.match({
+                            url: 'https://sonar.screwdriver.cd/api/projects/create?project=job:456&name=job:456'
+                        })
+                    );
+                });
+        });
+
         it('it throws err if failed to generate user token', () => {
             requestMock.onCall(5).rejects({
                 statusCode: 500,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -737,8 +737,10 @@ describe('index test', () => {
             enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
             requestMock.onCall(6).resolves({ body: { token: 'accesstoken' } });
 
+            // projectName/username are derived, not trusted, so pipelineName - the source they're derived
+            // from - is what the caller must supply.
             return enterpriseSonarPlugin
-                .getAccessToken({ buildCredentials, projectKey, username, projectName })
+                .getAccessToken({ buildCredentials, pipelineName: projectName })
                 .then(result => {
                     assert.callCount(requestMock, 7);
                     assert.call(
@@ -815,16 +817,14 @@ describe('index test', () => {
                 message: '500 - internal server error'
             });
 
-            const projectKey = 'pipeline:123';
             const projectName = 'd2lam/mytest';
-            const username = 'user-pipeline-123';
 
             enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
             requestMock.onCall(6).resolves({ body: { token: 'accesstoken' } });
 
             // eslint-disable-next-line max-len
             return enterpriseSonarPlugin
-                .getAccessToken({ buildCredentials, projectKey, username, projectName })
+                .getAccessToken({ buildCredentials, pipelineName: projectName })
                 .then(result => {
                     assert.callCount(requestMock, 7);
                     assert.callCount(loggerMock.error, 1);
@@ -835,16 +835,14 @@ describe('index test', () => {
         it('does not configure Git App if binding already exists', () => {
             requestMock.onCall(2).resolves({ repository: 'd2lam/mytest' });
 
-            const projectKey = 'pipeline:123';
             const projectName = 'd2lam/mytest';
-            const username = 'user-pipeline-123';
 
             enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
             requestMock.onCall(5).resolves({ body: { token: 'accesstoken' } });
 
             // eslint-disable-next-line max-len
             return enterpriseSonarPlugin
-                .getAccessToken({ buildCredentials, projectKey, username, projectName })
+                .getAccessToken({ buildCredentials, pipelineName: projectName })
                 .then(result => {
                     assert.callCount(requestMock, 6);
                     assert.callCount(loggerMock.error, 0);
@@ -855,16 +853,14 @@ describe('index test', () => {
         it('update Git App if project name has been changed', () => {
             requestMock.onCall(2).resolves({ repository: 'd2lam/oldname' });
 
-            const projectKey = 'pipeline:123';
             const projectName = 'd2lam/newname';
-            const username = 'user-pipeline-123';
 
             enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
             requestMock.onCall(6).resolves({ body: { token: 'accesstoken' } });
 
             // eslint-disable-next-line max-len
             return enterpriseSonarPlugin
-                .getAccessToken({ buildCredentials, projectKey, username, projectName })
+                .getAccessToken({ buildCredentials, pipelineName: projectName })
                 .then(result => {
                     assert.callCount(requestMock, 7);
                     assert.callCount(loggerMock.error, 0);
@@ -956,10 +952,12 @@ describe('index test', () => {
         });
 
         it('ignores a caller-supplied username and derives it from the project key', () => {
+            // sonarPlugin defaults to job scope, so job:1 (not pipeline:123) is the scope-consistent
+            // authorized key here.
             return sonarPlugin
                 .getAccessToken({
                     buildCredentials,
-                    projectKey: 'pipeline:123',
+                    projectKey: 'job:1',
                     projectName: 'd2lam/mytest',
                     username: 'admin'
                 })
@@ -967,10 +965,26 @@ describe('index test', () => {
                     assert.strictEqual(result, 'accesstoken');
                     assert.include(
                         requestMock.getCall(3).args[0].url,
-                        '/api/users/create?login=user-pipeline-123&name=user-pipeline-123&password='
+                        '/api/users/create?login=user-job-1&name=user-job-1&password='
                     );
                     assert.neverCalledWith(requestMock, sinon.match({ url: sinon.match('login=admin') }));
                 });
+        });
+
+        it("ignores an authorized-but-wrong-scope project key and re-derives from the build's own scope", () => {
+            // pipeline:123 is authorized for this build but does not match sonarPlugin's default job scope,
+            // so it must not cross the build into pipeline scope.
+            return sonarPlugin.getAccessToken({ buildCredentials, projectKey: 'pipeline:123' }).then(result => {
+                assert.strictEqual(result, 'accesstoken');
+                assert.calledWith(
+                    requestMock.firstCall,
+                    sinon.match({
+                        url: 'https://sonar.screwdriver.cd/api/projects/create?project=job:1&name=job:1'
+                    })
+                );
+                assert.neverCalledWith(requestMock, sinon.match({ url: sinon.match('pipeline:123') }));
+                assert.calledOnce(loggerMock.warn);
+            });
         });
 
         it('allows the PR parent job key for an enterprise PR build', () => {
@@ -984,7 +998,7 @@ describe('index test', () => {
                 .getAccessToken({
                     buildCredentials: prBuildCredentials,
                     projectKey: 'job:456',
-                    projectName: 'd2lam/mytest',
+                    pipelineName: 'd2lam/mytest',
                     scope: 'job'
                 })
                 .then(result => {
@@ -995,6 +1009,59 @@ describe('index test', () => {
                             url: 'https://sonar.screwdriver.cd/api/projects/create?project=job:456&name=job:456'
                         })
                     );
+                    // regression: this short-circuit branch must not put a literal "undefined:undefined"
+                    // repository on the wire when jobName isn't supplied
+                    assert.neverCalledWith(requestMock, sinon.match({ url: sinon.match('repository=undefined') }));
+                    assert.calledWith(
+                        requestMock.getCall(3),
+                        sinon.match({
+                            url: sinon.match('repository=d2lam/mytest')
+                        })
+                    );
+                });
+        });
+
+        it('resolves instead of throwing when enterprise job scope has no jobName to check for a PR shape', () => {
+            // Regression: getProjectData's PR-swap block used to call jobName.match() unconditionally,
+            // which threw a TypeError once _getAccessToken started calling getProjectData on every request.
+            const prBuildCredentials = { jobId: 1, pipelineId: 123, prParentJobId: 456, scmContext: 'github.com' };
+
+            enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
+            requestMock.onCall(6).resolves({ body: { token: 'accesstoken' } });
+
+            return enterpriseSonarPlugin
+                .getAccessToken({ buildCredentials: prBuildCredentials, scope: 'job', pipelineName: 'd2lam/mytest' })
+                .then(result => {
+                    assert.strictEqual(result, 'accesstoken');
+                    assert.calledWith(
+                        requestMock.firstCall,
+                        sinon.match({
+                            url: 'https://sonar.screwdriver.cd/api/projects/create?project=job:1&name=job:1'
+                        })
+                    );
+                });
+        });
+
+        it('never trusts a caller-supplied projectName, even alongside an authorized, scope-matching projectKey', () => {
+            // Regression: a prior revision trusted projectName whenever username/projectKey/projectName all
+            // looked "complete," which would let this build point another project's Git App binding at an
+            // arbitrary repository.
+            const projectKey = 'pipeline:123';
+
+            enterpriseSonarPlugin = new SonarPlugin(enterpriseConfig);
+
+            return enterpriseSonarPlugin
+                .getAccessToken({
+                    buildCredentials,
+                    projectKey,
+                    username: 'user-pipeline-123',
+                    projectName: 'victim/private-repo'
+                })
+                .then(result => {
+                    assert.strictEqual(result, 'accesstoken');
+                    requestMock.getCalls().forEach(call => {
+                        assert.notInclude(call.args[0].url, 'victim');
+                    });
                 });
         });
 


### PR DESCRIPTION
## Context
Sonar tokens aren't being tightly scoped to the project.

## Objective
Tightens the Sonar tokens to the actual project by validating the project ownership of the request to the sonar project itself.

## References

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
